### PR TITLE
fix(chungthuang): Make hero image optional in project collection

### DIFF
--- a/src/api/project/content-types/project/schema.json
+++ b/src/api/project/content-types/project/schema.json
@@ -28,7 +28,7 @@
     "heroImage": {
       "type": "media",
       "multiple": false,
-      "required": true,
+      "required": false,
       "allowedTypes": [
         "images",
         "files",


### PR DESCRIPTION
This makes it easier to create projects in development and testing