### PR TITLE
feat(chungthuang): Install plugin to return nested relations

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -10,7 +10,7 @@ jobs:
     - name: Use Node.js ${{ matrix.node-version }}
       uses: actions/setup-node@v1
       with:
-        node-version: '12.x'
+        node-version: '16.x'
     - run: npm install
     # TODO: Enable linter
     # - run: npx eslint .

--- a/package-lock.json
+++ b/package-lock.json
@@ -19,6 +19,7 @@
         "pg": "^8.7.3",
         "sharp": "^0.30.7",
         "strapi-plugin-entity-relationship-chart": "^4.1.0",
+        "strapi-plugin-populate-deep": "^2.0.0",
         "strapi-utils": "^3.6.11",
         "typescript": "^4.7.4"
       },
@@ -18376,10 +18377,20 @@
         "styled-components": ">= 2"
       }
     },
+    "node_modules/strapi-plugin-populate-deep": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/strapi-plugin-populate-deep/-/strapi-plugin-populate-deep-2.0.0.tgz",
+      "integrity": "sha512-IsdXZPjRiOnaczoQaXI6xfxnFqUhR70uW1VCRbY4a3hEmmocpCpIUGx7TiHdNPJOZuDiueTgEIQ4V5XEru9Lvw==",
+      "engines": {
+        "node": ">=14.19.1 <=18.x.x",
+        "npm": ">=6.0.0"
+      }
+    },
     "node_modules/strapi-utils": {
       "version": "3.6.11",
       "resolved": "https://registry.npmjs.org/strapi-utils/-/strapi-utils-3.6.11.tgz",
       "integrity": "sha512-62bDtQlpvVvgQPi5xC6AuGlr1KCVVVIPkF/CeMsKYfnbkmgpg9fjjM7PfASiDOr371t86KdmOYj2SXf0vNu1Yw==",
+      "deprecated": "Strapi V3 is no longer maintained",
       "dependencies": {
         "@sindresorhus/slugify": "1.1.0",
         "date-fns": "^2.19.0",
@@ -18780,9 +18791,9 @@
       "integrity": "sha512-VLghIWNM6ELQzo7zwmcg0NmTVyWKYjvIeM83yjp0wRDTmUnrM678fQbcKBo6n2CJEF0szoG//ytg+TKla89ALQ=="
     },
     "node_modules/through2/node_modules/readable-stream": {
-      "version": "2.3.7",
-      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.7.tgz",
-      "integrity": "sha512-Ebho8K4jIbHAxnuxi7o42OrZgF/ZTNcsZj6nRKyUmkhLFq8CHItp/fy6hQZuZmP/n3yZ9VBUbp4zz/mX8hmYPw==",
+      "version": "2.3.8",
+      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.8.tgz",
+      "integrity": "sha512-8p0AUk4XODgIewSi0l8Epjs+EVnWiK7NoDIEGU0HhE7+ZyY8D1IMY7odu5lRrFXGg71L15KG8QrPmum45RTtdA==",
       "dependencies": {
         "core-util-is": "~1.0.0",
         "inherits": "~2.0.3",
@@ -34357,6 +34368,11 @@
         }
       }
     },
+    "strapi-plugin-populate-deep": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/strapi-plugin-populate-deep/-/strapi-plugin-populate-deep-2.0.0.tgz",
+      "integrity": "sha512-IsdXZPjRiOnaczoQaXI6xfxnFqUhR70uW1VCRbY4a3hEmmocpCpIUGx7TiHdNPJOZuDiueTgEIQ4V5XEru9Lvw=="
+    },
     "strapi-utils": {
       "version": "3.6.11",
       "resolved": "https://registry.npmjs.org/strapi-utils/-/strapi-utils-3.6.11.tgz",
@@ -34661,9 +34677,9 @@
           "integrity": "sha512-VLghIWNM6ELQzo7zwmcg0NmTVyWKYjvIeM83yjp0wRDTmUnrM678fQbcKBo6n2CJEF0szoG//ytg+TKla89ALQ=="
         },
         "readable-stream": {
-          "version": "2.3.7",
-          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.7.tgz",
-          "integrity": "sha512-Ebho8K4jIbHAxnuxi7o42OrZgF/ZTNcsZj6nRKyUmkhLFq8CHItp/fy6hQZuZmP/n3yZ9VBUbp4zz/mX8hmYPw==",
+          "version": "2.3.8",
+          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.8.tgz",
+          "integrity": "sha512-8p0AUk4XODgIewSi0l8Epjs+EVnWiK7NoDIEGU0HhE7+ZyY8D1IMY7odu5lRrFXGg71L15KG8QrPmum45RTtdA==",
           "requires": {
             "core-util-is": "~1.0.0",
             "inherits": "~2.0.3",
@@ -35732,4 +35748,3 @@
     }
   }
 }
-

--- a/package.json
+++ b/package.json
@@ -20,6 +20,7 @@
     "pg": "^8.7.3",
     "sharp": "^0.30.7",
     "strapi-plugin-entity-relationship-chart": "^4.1.0",
+    "strapi-plugin-populate-deep": "^2.0.0",
     "strapi-utils": "^3.6.11",
     "typescript": "^4.7.4"
   },


### PR DESCRIPTION
By default, strapi wouldn't populate relational fields. The frontend can request it by adding `?populate=*`, but this only populate one-level deep. For projects collections, the team field is 2 level-deep. The query string becomes hard to craft, so we use this plugin that will return deeply nested relations.