### PR TITLE
fix(chungthuang): Fix token was not set because URL path didn't match

### DIFF
--- a/src/extensions/users-permissions/server/middlewares/jwt.js
+++ b/src/extensions/users-permissions/server/middlewares/jwt.js
@@ -12,7 +12,7 @@ module.exports = (options, { strapi }) => {
     await next();
     // Check if the route is local login or login with a provider
     // Set token in cookie
-    if (ctx.url.startsWith('/api/auth/local') || ctx.url.startsWith('/api/auth/connect')) {
+    if (ctx.url.startsWith('/api/auth/')) {
       const token = ctx.response.body.jwt;
       if (token) {
         /*


### PR DESCRIPTION
The path is `/api/auth/google/`, which doesn't match `/api/auth/connect`