### PR TITLE
fix(chungthuang): Sanitize fine one project response and return image of a project

### DIFF
--- a/src/api/project/controllers/project.js
+++ b/src/api/project/controllers/project.js
@@ -7,26 +7,28 @@ module.exports = createCoreController('api::project.project', ({ strapi }) => ({
         const slug = ctx.request.params.id;
         const entity = await strapi.db.query('api::project.project').findOne({
             where: { slug },
-            populate: ['team.leaders.leader', 'team.members.member', 'heroImage', 'interests', 'subProjects', 'opportunities']
+            populate: ['team.leaders.leader', 'team.members.member', 'heroImage', 'images', 'interests', 'subProjects', 'opportunities']
         });
 
         if (entity?.team) {
             entity.team.leaders = entity.team.leaders.map((leader) => ({
-                id: leader.leader.id,
-                username: leader.leader.username,
-                profile: leader.leader.profile,
-                email: leader.leader.email,
+                id: leader.leader?.id,
+                username: leader.leader?.username,
+                profile: leader.leader?.profile,
+                email: leader.leader?.email,
                 role: leader.role,
             }));
 
             entity.team.members = entity.team.members.map((member) => ({
-                id: member.member.id,
-                username: member.member.username,
-                profile: member.member.profile,
+                id: member.member?.id,
+                username: member.member?.username,
+                profile: member.member?.profile,
                 role: member.role,
             }));
         }
 
-        return entity;
+        const sanitizedResults = await this.sanitizeOutput(entity, ctx);
+
+        return this.transformResponse(sanitizedResults);
     },
 }));


### PR DESCRIPTION
Example response:
```
{
    "data": {
        "id": 1,
        "attributes": {
            "slug": "Dev-Recruiting",
            "catchPhase": "Join a new Project or Product that aligns with your personal goals!",
            "title": "Dev Recruit",
            "vision": "Dev Recruit will allow members and non- members to browse ideas, products and projects they can join and workshop through filters to easier align them with the right involvement in the Dev Launchers community.",
            "description": "Dev Recruit Project",
            "commitmentLevel": "Medium to High",
            "signupFormUrl": "http://localhost",
            "calendarId": null,
            "isListed": true,
            "createdAt": "2022-08-15T16:19:28.306Z",
            "updatedAt": "2023-11-29T21:12:39.799Z",
            "publishedAt": "2022-08-15T17:40:11.460Z",
            "discordWebhookUrl": null,
            "team": {
                "id": 1,
                "members": [
                    {
                        "id": 1,
                        "username": "integration-test",
                        "role": "dev"
                    }
                ],
                "leaders": []
            },
            "heroImage": {
                "data": null
            },
            "images": [],
            "interests": {
                "data": [
                    {
                        "id": 1,
                        "attributes": {
                            "interest": "Web Dev",
                            "createdAt": "2022-08-15T16:20:37.048Z",
                            "updatedAt": "2022-08-15T16:20:53.698Z",
                            "publishedAt": "2022-08-15T16:20:53.692Z"
                        }
                    }
                ]
            }
        }
    },
    "meta": {}
}
```