### PR TITLE
ops(chungthuang): Reduce health check frequency and increase timeout

### DIFF
--- a/workload/deployment.yaml
+++ b/workload/deployment.yaml
@@ -175,6 +175,6 @@ spec:
             path: /
             port: 1337
           initialDelaySeconds: 480
-          periodSeconds: 10
-          timeoutSeconds: 10
+          periodSeconds: 30
+          timeoutSeconds: 30
           failureThreshold: 5


### PR DESCRIPTION
This is a temporary workaround for heavy queries killing the pod because healthy checks can't be served