### PR TITLE
build(npm): only install deps if engines are compatible

### DIFF
--- a/.npmrc
+++ b/.npmrc
@@ -1,0 +1,1 @@
+engine-strict=true


### PR DESCRIPTION
With this change npm will stubbornly refuse to install (or even consider installing)
any package﻿ unless the engine requirements specified in package.json are met.
