### PR TITLE
fix: Check if the user has projects at beforeUpdate

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -29,7 +29,7 @@ module.exports = {
       async afterCreate({ result }) {
         const { projects } = result
         //ensure the new user is a member of a team before the team-membership entry is created
-        if (projects){
+        if (projects) {
           for (const project of projects) {
             await strapi.service("api::team-membership.team-membership").create({
               data: {
@@ -43,11 +43,11 @@ module.exports = {
       },
 
       async beforeUpdate({ params }) {
-        const joinProject = params.data.projects.connect;
-        const leftProject = params.data.projects.disconnect;
+        const joinProject = params?.data?.projects?.connect;
+        const leftProject = params?.data?.projects?.disconnect;
         const userId = params.data.id;
         // Find and update the leaveDate field in team-membership collection if a user leaves a project
-        if (leftProject.length > 0) {
+        if (leftProject?.length > 0) {
           for (const projectObj of leftProject) {
             const projectMembership = await strapi.query("api::team-membership.team-membership").findOne({
               where: {
@@ -67,7 +67,7 @@ module.exports = {
           }
         }
         // Create new team-membership entry if a user joins a new project
-        if (joinProject.length > 0) {
+        if (joinProject?.length > 0) {
           for (const projectObj of joinProject) {
             await strapi.service("api::team-membership.team-membership").create({
               data: {


### PR DESCRIPTION
### Changes
- Check if the user has projects at beforeUpdate lifeCycle to prevent the error when it is trying to get this property.

### Tests instructions

- Direct in the front-end:
Acces `http://localhost:3000/users/me` and in the interest tab, set an interest.

- Using postman:

    route: `http://localhost:1337/api/users/2`
    method: `put`
    payload:
`{
    "interests": [
        {
            "id": 1,
            "interest": "test",
            "createdAt": "2024-02-16T23:31:00.763Z",
            "updatedAt": "2024-02-16T23:31:03.788Z",
            "publishedAt": "2024-02-16T23:31:03.786Z",
            "users_permissions_users": {
                "data": []
            },
            "projects": {
                "data": []
            },
            "categories": {
                "data": []
            }
        }
    ]
}`


### Important points
- New projects collection type is crashing front-end:
  - front-end error: 
  ![image](https://github.com/dev-launchers/strapiv4/assets/81580990/b62492a2-1ff8-47a6-9860-35fe4b26f83e)
  - Solution: It is not related to fill a required or non-required filed. It is just necessary to add an empty team like bellow, and it worked as well:
  ![image](https://github.com/dev-launchers/strapiv4/assets/81580990/4c472602-5c4c-4840-b518-c610e9ba2aef)

