### PR TITLE
feat(notifications): Create subscription collection

### DIFF
--- a/init/permissions/authenticated.js
+++ b/init/permissions/authenticated.js
@@ -49,6 +49,11 @@ module.exports = {
         notification: readWrite,
       },
     },
+    "api::subscription": {
+      controllers: {
+        subscription: readOnly,
+      },
+    },
     "api::opportunity": {
       controllers: {
         opportunity: readOnly,

--- a/src/api/idea-card/content-types/idea-card/lifecycles.js
+++ b/src/api/idea-card/content-types/idea-card/lifecycles.js
@@ -16,7 +16,7 @@ module.exports = {
       data: {
         entityType: "IdeaCard",
         entityId: id,
-        TimeCreated: new Date(),
+        createdDateTime: new Date(),
         active: true,
         user: ctx.state.user,
       },

--- a/src/api/idea-card/content-types/idea-card/lifecycles.js
+++ b/src/api/idea-card/content-types/idea-card/lifecycles.js
@@ -1,18 +1,30 @@
 module.exports = {
 
   beforeCreate(event) {
-      // Set author and ideaOwner to the user sending the request
-      const ctx = strapi.requestContext.get();
-      event.params.data.author = ctx.state.user;
-      event.params.data.ideaOwner = ctx.state.user;
+    // Set author and ideaOwner to the user sending the request
+    const ctx = strapi.requestContext.get();
+    event.params.data.author = ctx.state.user;
+    event.params.data.ideaOwner = ctx.state.user;
   },
 
   async afterCreate(event) {
     const { id: id, ideaName: ideaName, createdAt: timeCreated } = event.result;
-    
+
+    const ctx = strapi.requestContext.get();
+
+    await strapi.entityService.create('api::subscription.subscription', {
+      data: {
+        entityType: "IdeaCard",
+        entityId: id,
+        TimeCreated: new Date(),
+        active: true,
+        user: ctx.state.user,
+      },
+    });
+
     await strapi.entityService.create('api::notification.notification', {
       data: {
-        Title:"A new idea has been created",
+        Title: "A new idea has been created",
         Content: "You created idea " + ideaName,
         entityType: "IdeaCard",
         entityId: id,

--- a/src/api/subscription/content-types/subscription/schema.json
+++ b/src/api/subscription/content-types/subscription/schema.json
@@ -8,7 +8,7 @@
     "description": ""
   },
   "options": {
-    "draftAndPublish": true
+    "draftAndPublish": false
   },
   "pluginOptions": {},
   "attributes": {

--- a/src/api/subscription/content-types/subscription/schema.json
+++ b/src/api/subscription/content-types/subscription/schema.json
@@ -35,6 +35,11 @@
     },
     "TimeCreated": {
       "type": "datetime"
+    },
+    "entityId": {
+      "type": "integer",
+      "required": true,
+      "unique": false
     }
   }
 }

--- a/src/api/subscription/content-types/subscription/schema.json
+++ b/src/api/subscription/content-types/subscription/schema.json
@@ -4,7 +4,8 @@
   "info": {
     "singularName": "subscription",
     "pluralName": "subscriptions",
-    "displayName": "Subscription"
+    "displayName": "Subscription",
+    "description": ""
   },
   "options": {
     "draftAndPublish": true
@@ -14,7 +15,7 @@
     "createdAt": {
       "type": "datetime"
     },
-    "unsubscribeAt": {
+    "TimeUnsubscribed": {
       "type": "datetime"
     },
     "active": {
@@ -25,6 +26,15 @@
       "relation": "manyToOne",
       "target": "plugin::users-permissions.user",
       "inversedBy": "subscriptions"
+    },
+    "entityType": {
+      "type": "enumeration",
+      "enum": [
+        "IdeaCard"
+      ]
+    },
+    "TimeCreated": {
+      "type": "datetime"
     }
   }
 }

--- a/src/api/subscription/content-types/subscription/schema.json
+++ b/src/api/subscription/content-types/subscription/schema.json
@@ -1,0 +1,30 @@
+{
+  "kind": "collectionType",
+  "collectionName": "subscriptions",
+  "info": {
+    "singularName": "subscription",
+    "pluralName": "subscriptions",
+    "displayName": "Subscription"
+  },
+  "options": {
+    "draftAndPublish": true
+  },
+  "pluginOptions": {},
+  "attributes": {
+    "createdAt": {
+      "type": "datetime"
+    },
+    "unsubscribeAt": {
+      "type": "datetime"
+    },
+    "active": {
+      "type": "boolean"
+    },
+    "user": {
+      "type": "relation",
+      "relation": "manyToOne",
+      "target": "plugin::users-permissions.user",
+      "inversedBy": "subscriptions"
+    }
+  }
+}

--- a/src/api/subscription/content-types/subscription/schema.json
+++ b/src/api/subscription/content-types/subscription/schema.json
@@ -33,9 +33,6 @@
         "IdeaCard"
       ]
     },
-    "TimeCreated": {
-      "type": "datetime"
-    },
     "entityId": {
       "type": "integer",
       "required": true,

--- a/src/api/subscription/content-types/subscription/schema.json
+++ b/src/api/subscription/content-types/subscription/schema.json
@@ -12,10 +12,10 @@
   },
   "pluginOptions": {},
   "attributes": {
-    "createdAt": {
+    "createdDateTime": {
       "type": "datetime"
     },
-    "TimeUnsubscribed": {
+    "unsubscribedDateTime": {
       "type": "datetime"
     },
     "active": {

--- a/src/api/subscription/controllers/subscription.js
+++ b/src/api/subscription/controllers/subscription.js
@@ -1,0 +1,9 @@
+'use strict';
+
+/**
+ * subscription controller
+ */
+
+const { createCoreController } = require('@strapi/strapi').factories;
+
+module.exports = createCoreController('api::subscription.subscription');

--- a/src/api/subscription/routes/subscription.js
+++ b/src/api/subscription/routes/subscription.js
@@ -1,0 +1,9 @@
+'use strict';
+
+/**
+ * subscription router
+ */
+
+const { createCoreRouter } = require('@strapi/strapi').factories;
+
+module.exports = createCoreRouter('api::subscription.subscription');

--- a/src/api/subscription/services/subscription.js
+++ b/src/api/subscription/services/subscription.js
@@ -1,0 +1,9 @@
+'use strict';
+
+/**
+ * subscription service
+ */
+
+const { createCoreService } = require('@strapi/strapi').factories;
+
+module.exports = createCoreService('api::subscription.subscription');

--- a/src/extensions/users-permissions/content-types/user/schema.json
+++ b/src/extensions/users-permissions/content-types/user/schema.json
@@ -165,6 +165,12 @@
       "relation": "oneToMany",
       "target": "api::comment.comment",
       "mappedBy": "authorId"
+    },
+    "subscriptions": {
+      "type": "relation",
+      "relation": "oneToMany",
+      "target": "api::subscription.subscription",
+      "mappedBy": "user"
     }
   }
 }

--- a/tests/subscription.spec.ts
+++ b/tests/subscription.spec.ts
@@ -21,8 +21,7 @@ test.describe('/api/subscriptions', () => {
 
         const subscription = subscriptions.data
             .find(item => (item.attributes.entityId === newIdea.id && item.attributes.entityType === "IdeaCard"));
-        console.log('subscription ->', subscription);
-        // expect(subscription.attributes.user.id).toBe(user.id)
+        // expect(subscription.attributes.user.id).toBe(user.id);
         expect(subscription.attributes.TimeCreated).toBeDefined();
         expect(subscription.attributes.active).toBe(true);
     })

--- a/tests/subscription.spec.ts
+++ b/tests/subscription.spec.ts
@@ -22,7 +22,7 @@ test.describe('/api/subscriptions', () => {
         const subscription = subscriptions.data
             .find(item => (item.attributes.entityId === newIdea.id && item.attributes.entityType === "IdeaCard"));
         // expect(subscription.attributes.user.id).toBe(user.id);
-        expect(subscription.attributes.TimeCreated).toBeDefined();
+        expect(subscription.attributes.createdDateTime).toBeDefined();
         expect(subscription.attributes.active).toBe(true);
     })
 })

--- a/tests/subscription.spec.ts
+++ b/tests/subscription.spec.ts
@@ -1,0 +1,29 @@
+import { test, expect } from '@playwright/test';
+import { api } from './utils';
+import { user } from '../init/config';
+
+test.describe('/api/subscriptions', () => {
+    test("Create a subscription when idea is created", async ({ request }) => {
+        const newIdea = await api(request).post("/api/idea-cards", {
+            ideaName: "Testing with subs 1",
+            tagline: "Yay!",
+            description: "I am testing",
+            targetAudience: "Yes",
+            features: "Yes",
+            experience: "Yes",
+            extraInfo: "Yes",
+            involveLevel: "minimum",
+            status: "workshopping",
+        });
+
+        const subscriptions = await api(request).get("/api/subscriptions");
+
+
+        const subscription = subscriptions.data
+            .find(item => (item.attributes.entityId === newIdea.id && item.attributes.entityType === "IdeaCard"));
+        console.log('subscription ->', subscription);
+        // expect(subscription.attributes.user.id).toBe(user.id)
+        expect(subscription.attributes.TimeCreated).toBeDefined();
+        expect(subscription.attributes.active).toBe(true);
+    })
+})

--- a/types/generated/contentTypes.d.ts
+++ b/types/generated/contentTypes.d.ts
@@ -1467,8 +1467,8 @@ export interface ApiSubscriptionSubscription extends Schema.CollectionType {
     draftAndPublish: false;
   };
   attributes: {
-    createdAt: Attribute.DateTime;
-    TimeUnsubscribed: Attribute.DateTime;
+    createdDateTime: Attribute.DateTime;
+    unsubscribedDateTime: Attribute.DateTime;
     active: Attribute.Boolean;
     user: Attribute.Relation<
       'api::subscription.subscription',
@@ -1476,8 +1476,8 @@ export interface ApiSubscriptionSubscription extends Schema.CollectionType {
       'plugin::users-permissions.user'
     >;
     entityType: Attribute.Enumeration<['IdeaCard']>;
-    TimeCreated: Attribute.DateTime;
     entityId: Attribute.Integer & Attribute.Required;
+    createdAt: Attribute.DateTime;
     updatedAt: Attribute.DateTime;
     createdBy: Attribute.Relation<
       'api::subscription.subscription',

--- a/types/generated/contentTypes.d.ts
+++ b/types/generated/contentTypes.d.ts
@@ -666,6 +666,11 @@ export interface PluginUsersPermissionsUser extends Schema.CollectionType {
       'oneToMany',
       'api::comment.comment'
     >;
+    subscriptions: Attribute.Relation<
+      'plugin::users-permissions.user',
+      'oneToMany',
+      'api::subscription.subscription'
+    >;
     createdAt: Attribute.DateTime;
     updatedAt: Attribute.DateTime;
     createdBy: Attribute.Relation<
@@ -1450,6 +1455,45 @@ export interface ApiSendmailSendmail extends Schema.CollectionType {
   };
 }
 
+export interface ApiSubscriptionSubscription extends Schema.CollectionType {
+  collectionName: 'subscriptions';
+  info: {
+    singularName: 'subscription';
+    pluralName: 'subscriptions';
+    displayName: 'Subscription';
+    description: '';
+  };
+  options: {
+    draftAndPublish: true;
+  };
+  attributes: {
+    createdAt: Attribute.DateTime;
+    TimeUnsubscribed: Attribute.DateTime;
+    active: Attribute.Boolean;
+    user: Attribute.Relation<
+      'api::subscription.subscription',
+      'manyToOne',
+      'plugin::users-permissions.user'
+    >;
+    entityType: Attribute.Enumeration<['IdeaCard']>;
+    TimeCreated: Attribute.DateTime;
+    updatedAt: Attribute.DateTime;
+    publishedAt: Attribute.DateTime;
+    createdBy: Attribute.Relation<
+      'api::subscription.subscription',
+      'oneToOne',
+      'admin::user'
+    > &
+      Attribute.Private;
+    updatedBy: Attribute.Relation<
+      'api::subscription.subscription',
+      'oneToOne',
+      'admin::user'
+    > &
+      Attribute.Private;
+  };
+}
+
 export interface ApiTeamMembershipTeamMembership extends Schema.CollectionType {
   collectionName: 'team_memberships';
   info: {
@@ -1526,6 +1570,7 @@ declare module '@strapi/types' {
       'api::project.project': ApiProjectProject;
       'api::save-idea.save-idea': ApiSaveIdeaSaveIdea;
       'api::sendmail.sendmail': ApiSendmailSendmail;
+      'api::subscription.subscription': ApiSubscriptionSubscription;
       'api::team-membership.team-membership': ApiTeamMembershipTeamMembership;
     }
   }

--- a/types/generated/contentTypes.d.ts
+++ b/types/generated/contentTypes.d.ts
@@ -1464,7 +1464,7 @@ export interface ApiSubscriptionSubscription extends Schema.CollectionType {
     description: '';
   };
   options: {
-    draftAndPublish: true;
+    draftAndPublish: false;
   };
   attributes: {
     createdAt: Attribute.DateTime;
@@ -1479,7 +1479,6 @@ export interface ApiSubscriptionSubscription extends Schema.CollectionType {
     TimeCreated: Attribute.DateTime;
     entityId: Attribute.Integer & Attribute.Required;
     updatedAt: Attribute.DateTime;
-    publishedAt: Attribute.DateTime;
     createdBy: Attribute.Relation<
       'api::subscription.subscription',
       'oneToOne',

--- a/types/generated/contentTypes.d.ts
+++ b/types/generated/contentTypes.d.ts
@@ -1477,6 +1477,7 @@ export interface ApiSubscriptionSubscription extends Schema.CollectionType {
     >;
     entityType: Attribute.Enumeration<['IdeaCard']>;
     TimeCreated: Attribute.DateTime;
+    entityId: Attribute.Integer & Attribute.Required;
     updatedAt: Attribute.DateTime;
     publishedAt: Attribute.DateTime;
     createdBy: Attribute.Relation<


### PR DESCRIPTION
## Required points discussed in the meeting of May-12:
- [x] Finalize the collection.
- [x] Update the collection names as similar as notification.
- [x] Add the behavior to create a subscription when user creates an idea.
- [x] Add test for idea creation and subscription create.
- [x] ~Fix this test ``expect(subscription.attributes.user.id).toBe(user.id)``~ (TBD in during Notification feature integration)
- [x] ~Verify that subscription are not available in API.~ (TBD in during Notification feature integration)

