### PR TITLE
ops: Tolerate scheduling prouction deployment on virtual node

### DIFF
--- a/workload/deployment.yaml
+++ b/workload/deployment.yaml
@@ -16,6 +16,13 @@ spec:
       labels:
         app: strapi
     spec:
+      # Prefer to not schedule on the virtual node. But if the cluster is running out of memory, schedule on the virtual node
+      # so at least we have a pod running
+      # https://learn.microsoft.com/en-us/azure/aks/virtual-nodes-cli#deploy-a-sample-app
+      tolerations:
+      - key: virtual-kubelet.io/provider
+        operator: Exists
+        effect: PreferNoSchedule
       volumes:
         - name: google-directory-key
           secret:


### PR DESCRIPTION
Tested by applying the deployment in dry run mode:
```
$ kubectl apply -f workload/deployment.yaml --dry-run
deployment.apps/strapi configured (dry run)
```