### PR TITLE
Added the 'isAgeOver18' and 'isTermsAgreed' columns to the Applicant Schema

### DIFF
--- a/src/api/applicant/content-types/applicant/schema.json
+++ b/src/api/applicant/content-types/applicant/schema.json
@@ -55,7 +55,11 @@
     },
     "level": {
       "type": "enumeration",
-      "enum": ["beginner", "intermediate", "advanced"],
+      "enum": [
+        "beginner",
+        "intermediate",
+        "advanced"
+      ],
       "required": true
     },
     "skills": {
@@ -68,6 +72,16 @@
       "required": true,
       "min": 0,
       "max": 100
+    },
+    "isAgeOver18": {
+      "type": "boolean",
+      "default": true,
+      "required": true
+    },
+    "isTermsAgreed": {
+      "type": "boolean",
+      "default": true,
+      "required": true
     }
   }
 }

--- a/types/generated/contentTypes.d.ts
+++ b/types/generated/contentTypes.d.ts
@@ -762,6 +762,12 @@ export interface ApiApplicantApplicant extends Schema.CollectionType {
         min: 0;
         max: 100;
       }>;
+    isAgeOver18: Attribute.Boolean &
+      Attribute.Required &
+      Attribute.DefaultTo<true>;
+    isTermsAgreed: Attribute.Boolean &
+      Attribute.Required &
+      Attribute.DefaultTo<true>;
     createdAt: Attribute.DateTime;
     updatedAt: Attribute.DateTime;
     publishedAt: Attribute.DateTime;


### PR DESCRIPTION
Zenhub - https://app.zenhub.com/workspaces/devrecruit-team-644b85772003020cab70d47e/issues/gh/dev-launchers/dev-launchers-platform/1898

As per the requirement, I have added the isAgeOver18 and isTermsAgreed columns to the applicant schema.

