### PR TITLE
Tiago/51 cannot reset password with admin endpoint

### DIFF
--- a/config/plugins.js
+++ b/config/plugins.js
@@ -64,5 +64,22 @@ module.exports = ({ env }) => ({
         name: "strapi-prometheus",
       },
     }
-  }
+  },
+  email: {
+    config: {
+      provider: 'nodemailer',
+      providerOptions: {
+        host: 'smtp.gmail.com',
+        port: 465,
+        auth: {
+          user: "email@gmail.com", // edit here
+          pass: "zzzz zzzz zzzz zzzz", // edit here
+        },
+      },
+      settings: {
+        defaultFrom: 'hello@example.com',
+        defaultReplyTo: 'hello@example.com',
+      },
+    },
+  },
 });

--- a/config/plugins.js
+++ b/config/plugins.js
@@ -72,13 +72,13 @@ module.exports = ({ env }) => ({
         host: 'smtp.gmail.com',
         port: 465,
         auth: {
-          user: "email@gmail.com", // edit here
-          pass: "zzzz zzzz zzzz zzzz", // edit here
+          user: env('NODE_MAILER_EMAIL'),
+          pass: env('NODE_MAILER_PASSWORD')
         },
       },
       settings: {
-        defaultFrom: 'hello@example.com',
-        defaultReplyTo: 'hello@example.com',
+        defaultFrom: env('NODE_MAILER_EMAIL'),
+        defaultReplyTo: env('NODE_MAILER_EMAIL'),
       },
     },
   },

--- a/package-lock.json
+++ b/package-lock.json
@@ -13,6 +13,7 @@
         "@strapi/plugin-i18n": "4.15.0",
         "@strapi/plugin-sentry": "4.15.0",
         "@strapi/plugin-users-permissions": "4.15.0",
+        "@strapi/provider-email-nodemailer": "^5.0.1",
         "@strapi/strapi": "4.15.0",
         "better-sqlite3": "^9.2.2",
         "discord-webhook-node": "^1.1.8",
@@ -4715,6 +4716,27 @@
       "engines": {
         "node": ">=18.0.0 <=20.x.x",
         "npm": ">=6.0.0"
+      }
+    },
+    "node_modules/@strapi/provider-email-nodemailer": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/@strapi/provider-email-nodemailer/-/provider-email-nodemailer-5.0.1.tgz",
+      "integrity": "sha512-VqdkMNPoifMtREQdUIFO9BG7+X0Zum7TnbsKidUZOiQEup+ko6QZ1P9+hyDgS+fyu8IBF5BG+l7C6LeS98c3cA==",
+      "dependencies": {
+        "lodash": "4.17.21",
+        "nodemailer": "6.9.1"
+      },
+      "engines": {
+        "node": ">=18.0.0 <=20.x.x",
+        "npm": ">=6.0.0"
+      }
+    },
+    "node_modules/@strapi/provider-email-nodemailer/node_modules/nodemailer": {
+      "version": "6.9.1",
+      "resolved": "https://registry.npmjs.org/nodemailer/-/nodemailer-6.9.1.tgz",
+      "integrity": "sha512-qHw7dOiU5UKNnQpXktdgQ1d3OFgRAekuvbJLcdG5dnEo/GtcTHRYM7+UfJARdOFU9WUQO8OiIamgWPmiSFHYAA==",
+      "engines": {
+        "node": ">=6.0.0"
       }
     },
     "node_modules/@strapi/provider-email-sendmail": {
@@ -23430,6 +23452,22 @@
       "version": "4.15.0",
       "resolved": "https://registry.npmjs.org/@strapi/provider-audit-logs-local/-/provider-audit-logs-local-4.15.0.tgz",
       "integrity": "sha512-L7tLXK9RpIKpIYRRf8lVcfNMWbRHhN5XSlLTGrXnPPe3ilCpAbuxhKhlQLA+Rj12xsD6fccFOAoNa4XXpNvWlw=="
+    },
+    "@strapi/provider-email-nodemailer": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/@strapi/provider-email-nodemailer/-/provider-email-nodemailer-5.0.1.tgz",
+      "integrity": "sha512-VqdkMNPoifMtREQdUIFO9BG7+X0Zum7TnbsKidUZOiQEup+ko6QZ1P9+hyDgS+fyu8IBF5BG+l7C6LeS98c3cA==",
+      "requires": {
+        "lodash": "4.17.21",
+        "nodemailer": "6.9.1"
+      },
+      "dependencies": {
+        "nodemailer": {
+          "version": "6.9.1",
+          "resolved": "https://registry.npmjs.org/nodemailer/-/nodemailer-6.9.1.tgz",
+          "integrity": "sha512-qHw7dOiU5UKNnQpXktdgQ1d3OFgRAekuvbJLcdG5dnEo/GtcTHRYM7+UfJARdOFU9WUQO8OiIamgWPmiSFHYAA=="
+        }
+      }
     },
     "@strapi/provider-email-sendmail": {
       "version": "4.15.0",

--- a/package.json
+++ b/package.json
@@ -20,6 +20,7 @@
     "@strapi/plugin-i18n": "4.15.0",
     "@strapi/plugin-sentry": "4.15.0",
     "@strapi/plugin-users-permissions": "4.15.0",
+    "@strapi/provider-email-nodemailer": "^5.0.1",
     "@strapi/strapi": "4.15.0",
     "better-sqlite3": "^9.2.2",
     "discord-webhook-node": "^1.1.8",

--- a/types/package-lock.json
+++ b/types/package-lock.json
@@ -1,0 +1,13 @@
+{
+  "name": "devlaunchers-strapi",
+  "version": "1.0.0",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "devlaunchers-strapi",
+      "version": "1.0.0",
+      "license": "ISC"
+    }
+  }
+}

--- a/workload/deployment.yaml
+++ b/workload/deployment.yaml
@@ -145,6 +145,16 @@ spec:
           value: info
         - name: AUDIT_FREQ_MINUTES
           value: "60"
+        - name: NODE_MAILER_EMAIL
+          valueFrom:
+            secretKeyRef:
+              name: nodemailer
+              key: user
+        - name: NODE_MAILER_PASSWORD
+          valueFrom:
+            secretKeyRef:
+              name: nodemailer
+              key: password
         - name: SENTRY_DSN
           valueFrom:
             secretKeyRef:


### PR DESCRIPTION
## Changes
- Adding the pluging to enable send emails using strapi.

## How to test
- Generate a gmail passkey
- Go to config/plugins.js, and include your email and passkey at email.config.providerOptions.auth
- Go to http://localhost:1337/admin/settings/email and send and email test.

## Next steps
- Move the credentials to a .env file.
- Enable the route forgot-pasword.