### PR TITLE
fix(package): Fix package name that we publish to be under @devlaunchers and make the scope publicfix(package): Fix package name that we publish to be under @devlaunchers and make the scope public

### DIFF
--- a/.github/workflows/publish-types.yaml
+++ b/.github/workflows/publish-types.yaml
@@ -26,11 +26,6 @@ jobs:
           node-version: '20'
           registry-url : 'https://registry.npmjs.org'
 
-      - name: Configure npm
-        run: |
-          echo "//registry.npmjs.org/:_authToken=${{ secrets.NPM_TOKEN }}" > ~/.npmrc
-          echo "registry=https://registry.npmjs.org" >> ~/.npmrc
-
       - name: Install dependencies
         run: npm install
 

--- a/types/package.json
+++ b/types/package.json
@@ -1,9 +1,9 @@
 {
-  "name": "devlaunchers-strapi",
+  "name": "@devlaunchers/strapi-test",
   "version": "1.0.0",
   "main": "index.js",
   "scripts": {
-    "publish:types": "npm publish"
+    "publish:types": "npm publish --access=public"
   },
   "keywords": [],
   "author": "",


### PR DESCRIPTION
This was tested locally and the package was published to https://www.npmjs.com/package/@devlaunchers/strapi?activeTab=code.