### PR TITLE
feat(event): Update event schema with action and (Latest) entityName, removed title

### DIFF
--- a/src/api/comment/content-types/comment/lifecycles.js
+++ b/src/api/comment/content-types/comment/lifecycles.js
@@ -18,8 +18,9 @@ module.exports = {
 
     strapi.entityService.create('api::event.event', {
       data: {
-        title: `${user.username} commented on ${idea?.ideaName}`,
-        content: commentText,
+        action: "Commented",
+        entityName: commentText,
+        content: `${user.username} commented on idea: ${idea?.ideaName}`,
         entityType: "IdeaCard",
         entityId: idea?.id,
         eventUser: user?.id,

--- a/src/api/comment/content-types/comment/lifecycles.js
+++ b/src/api/comment/content-types/comment/lifecycles.js
@@ -21,7 +21,7 @@ module.exports = {
         action: "Commented",
         entityName: commentText,
         content: `${user.username} commented on idea: ${idea?.ideaName}`,
-        entityType: "IdeaCard",
+        entityType: "Comment",
         entityId: idea?.id,
         eventUser: user?.id,
         createdDateTime: new Date(),

--- a/src/api/event/content-types/event/schema.json
+++ b/src/api/event/content-types/event/schema.json
@@ -21,9 +21,6 @@
         "IdeaCard"
       ]
     },
-    "title": {
-      "type": "string"
-    },
     "content": {
       "type": "text"
     },
@@ -34,6 +31,18 @@
       "type": "relation",
       "relation": "oneToOne",
       "target": "plugin::users-permissions.user"
+    },
+    "action": {
+      "type": "enumeration",
+      "enum": [
+        "Idea Created",
+        "Idea Updated",
+        "Commented",
+        "Liked"
+      ]
+    },
+    "entityName": {
+      "type": "string"
     }
   }
 }

--- a/src/api/event/content-types/event/schema.json
+++ b/src/api/event/content-types/event/schema.json
@@ -18,7 +18,8 @@
     "entityType": {
       "type": "enumeration",
       "enum": [
-        "IdeaCard"
+        "IdeaCard",
+        "Comment"
       ]
     },
     "content": {

--- a/src/api/event/controllers/event.js
+++ b/src/api/event/controllers/event.js
@@ -1,9 +1,30 @@
-'use strict';
-
-/**
- * event controller
- */
-
 const { createCoreController } = require('@strapi/strapi').factories;
 
-module.exports = createCoreController('api::event.event');
+module.exports = createCoreController('api::event.event', ({ strapi }) => ({
+
+  async find(ctx) {
+    const events = await strapi.entityService.findMany('api::event.event', {
+      populate: ['eventUser'],
+    });
+
+    // Retrieve latest entityName for each event Dynamically
+    const enhancedEvents = await Promise.all(events.map(async (event) => {
+      let entityName = '';
+
+      if (event.entityType === 'IdeaCard') {
+        const ideaCard = await strapi.entityService.findOne('api::idea-card.idea-card', event.entityId);
+        entityName = ideaCard ? ideaCard.ideaName : 'Unknown Idea';
+      } else if (event.entityType === 'Comment') {
+        const comment = await strapi.entityService.findOne('api::comment.comment', event.entityId);
+        entityName = comment ? comment.text : 'Unknown Comment';
+      }
+
+      return {
+        ...event,
+        entityName,  // Adding the dynamic (latest) entityName to the event
+      };
+    }));
+
+    return enhancedEvents;
+  },
+}));

--- a/src/api/event/controllers/event.js
+++ b/src/api/event/controllers/event.js
@@ -1,14 +1,22 @@
 const { createCoreController } = require('@strapi/strapi').factories;
 
 module.exports = createCoreController('api::event.event', ({ strapi }) => ({
-
   async find(ctx) {
+    // filter with the query
+    const { entityId, entityType } = ctx.query;
+
+    // Fetch only the events that match the filters
+    const filters = {};
+    if (entityId) filters.entityId = entityId;
+    if (entityType) filters.entityType = entityType;
+
     const events = await strapi.entityService.findMany('api::event.event', {
-      populate: ['eventUser'],
+      filters,  // Apply filters to fetch specific events
+      populate: ['eventUser'],  // Populate relations (e.g., eventUser)
     });
 
     // Retrieve latest entityName for each event Dynamically
-    const enhancedEvents = await Promise.all(events.map(async (event) => {
+    const latestEvents = await Promise.all(events.map(async (event) => {
       let entityName = '';
 
       if (event.entityType === 'IdeaCard') {
@@ -25,6 +33,6 @@ module.exports = createCoreController('api::event.event', ({ strapi }) => ({
       };
     }));
 
-    return enhancedEvents;
+    return latestEvents;  // Return the latest list of events
   },
 }));

--- a/src/api/idea-card/content-types/idea-card/lifecycles.js
+++ b/src/api/idea-card/content-types/idea-card/lifecycles.js
@@ -25,7 +25,8 @@ module.exports = {
 
     await strapi.entityService.create('api::event.event', {
       data: {
-        title:"Idea Submitted Successfully",
+        action:"Idea Created",
+        entityName: ideaName,
         content: `${author} added new idea, ${ideaName} - ${tagline} is created`,
         entityType: "IdeaCard",
         entityId: id,
@@ -57,7 +58,8 @@ module.exports = {
 
     await strapi.entityService.create('api::event.event', {
       data: {
-        title,
+        action: "Idea Updated",
+        entityName: ideaName,
         content,
         entityType: 'IdeaCard',
         entityId: id,

--- a/types/generated/contentTypes.d.ts
+++ b/types/generated/contentTypes.d.ts
@@ -910,7 +910,6 @@ export interface ApiEventEvent extends Schema.CollectionType {
   attributes: {
     entityId: Attribute.Integer;
     entityType: Attribute.Enumeration<['IdeaCard']>;
-    title: Attribute.String;
     content: Attribute.Text;
     createdDateTime: Attribute.DateTime;
     eventUser: Attribute.Relation<
@@ -918,6 +917,10 @@ export interface ApiEventEvent extends Schema.CollectionType {
       'oneToOne',
       'plugin::users-permissions.user'
     >;
+    action: Attribute.Enumeration<
+      ['Idea Created', 'Idea Updated', 'Commented', 'Liked']
+    >;
+    entityName: Attribute.String;
     createdAt: Attribute.DateTime;
     updatedAt: Attribute.DateTime;
     createdBy: Attribute.Relation<

--- a/types/generated/contentTypes.d.ts
+++ b/types/generated/contentTypes.d.ts
@@ -909,7 +909,7 @@ export interface ApiEventEvent extends Schema.CollectionType {
   };
   attributes: {
     entityId: Attribute.Integer;
-    entityType: Attribute.Enumeration<['IdeaCard']>;
+    entityType: Attribute.Enumeration<['IdeaCard', 'Comment']>;
     content: Attribute.Text;
     createdDateTime: Attribute.DateTime;
     eventUser: Attribute.Relation<


### PR DESCRIPTION
The event schema has been updated with the **action** that triggered its creation, the latest **entityName** which references the collection that created it (e.g: ideaName, CommentText, etc). The **title** is removed to enable easy consumption of the API.