### PR TITLE
fix(package): Fix the package name for published types

### DIFF
--- a/types/package.json
+++ b/types/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "@devlaunchers/strapi-test",
+  "name": "@devlaunchers/strapi",
   "version": "1.0.0",
   "main": "index.js",
   "scripts": {


### PR DESCRIPTION
https://github.com/dev-launchers/strapiv4/actions/workflows/publish-types.yaml is failing to authenticate. I think this will fix the authentication issue, but the publication won't work yet, because we are not updating the package version.