### PR TITLE
Add initial Nomad configuration for Metabase deployment

### DIFF
--- a/nomad-metabase/metabase.nomad
+++ b/nomad-metabase/metabase.nomad
@@ -1,0 +1,38 @@
+job "metabase" {
+  datacenters = ["dc1"]
+  type = "service"
+
+  group "metabase-group" {
+    count = 1
+
+    network {
+      port "http" {
+        static = 3000
+      }
+    }
+
+    task "metabase" {
+      driver = "docker"
+
+      config {
+        image = "metabase/metabase:latest"
+        ports = ["http"]
+      }
+
+      resources {
+        cpu    = 500
+        memory = 1024
+      }
+
+      env {
+        MB_JETTY_PORT = "3000"
+      }
+    }
+
+    service {
+      provider = "nomad"
+      name = "metabase"
+      port = "http"
+    }
+  }
+}

--- a/nomad-metabase/nomad.hcl
+++ b/nomad-metabase/nomad.hcl
@@ -1,0 +1,11 @@
+client {
+  enabled = true
+
+  options {
+    # Use Docker via Windows named pipe
+    "driver.docker.endpoint" = "npipe:////./pipe/docker_engine"
+
+    # Disable raw_exec (not supported on Windows)
+    "driver.raw_exec.enable" = "0"
+  }
+}

--- a/src/plugins/googledrive/package-lock.json
+++ b/src/plugins/googledrive/package-lock.json
@@ -1,11 +1,11 @@
 {
-  "name": "googledrive",
+  "name": "strapi-plugin-googledrive",
   "version": "0.0.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
-      "name": "googledrive",
+      "name": "strapi-plugin-googledrive",
       "version": "0.0.0",
       "license": "MIT",
       "dependencies": {

--- a/types/package-lock.json
+++ b/types/package-lock.json
@@ -1,11 +1,11 @@
 {
-  "name": "devlaunchers-strapi",
+  "name": "@devlaunchers/strapi-test",
   "version": "1.0.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
-      "name": "devlaunchers-strapi",
+      "name": "@devlaunchers/strapi-test",
       "version": "1.0.0",
       "license": "ISC"
     }


### PR DESCRIPTION
**Summary**
This PR introduces the initial Nomad configuration required to deploy Metabase for internal reporting. It includes a job specification that enables local deployment, with the intention of expanding this setup for production use.

**Changes Introduced**
- Added Nomad job file for deploying Metabase locally.
- Configured necessary resources (e.g., ports, task driver, image).
- Verified local deployment and UI accessibility.

**Next Steps**
- Evaluate persistent storage setup.
- Configure environment-specific variables for production.

**Reference**
Internal issue: [#238](https://github.com/dev-launchers/strapiv4/issues/238)

Nomad Docs: https://developer.hashicorp.com/nomad