### PR TITLE
Fix file upload and delete functionality with permission handling (#1254)

### DIFF
--- a/config/plugins.js
+++ b/config/plugins.js
@@ -91,6 +91,7 @@ module.exports = ({ env }) => ({
         publicFiles: true,
         uniform: false,
         serviceAccount: env.json('GOOGLE_DRIVE_SERVICE_ACCOUNT'),
+        folderId: env('FOLDERID'),
       },
     },
   },

--- a/config/plugins.js
+++ b/config/plugins.js
@@ -91,7 +91,7 @@ module.exports = ({ env }) => ({
         publicFiles: true,
         uniform: false,
         serviceAccount: env.json('GOOGLE_DRIVE_SERVICE_ACCOUNT'),
-        folderId: env('FOLDERID'),
+        folderId: env('GOOGLE_DRIVE_FOLDERID'),
       },
     },
   },

--- a/src/plugins/googledrive/server/services/operation-service.js
+++ b/src/plugins/googledrive/server/services/operation-service.js
@@ -1,25 +1,19 @@
 'use strict';
-const path = require('path');
-const process = require('process');
 const { google } = require('googleapis');
-// const get_service_account_path = () => {
-//   const service_account_path = path.join(
-//     process.cwd(),
-//     'config',
-//     'env',
-//     'google_drive_service_account.json'
-//   );
-//   return service_account_path;
-// };
 module.exports = ({ strapi }) => ({
   get: async (ctx) => {
-    // const google_drive_service_account_path = get_service_account_path();
-    
     const serviceAccount = strapi.config.get('plugin.googledrive.providerOptions.serviceAccount');
-
+    const folderId = strapi.config.get('plugin.googledrive.providerOptions.folderId');
+    if (!serviceAccount) {
+      ctx.throw(500, 'Google Drive plugin is not configured: serviceAccount is missing');
+      return;
+    }
+    if (!folderId) {
+      ctx.throw(500, 'Google Drive plugin is not configured: folderId is missing');
+      return;
+    }
     const scopes = ['https://www.googleapis.com/auth/drive.metadata.readonly'];
     const auth = new google.auth.GoogleAuth({
-      // keyFile: google_drive_service_account_path,
       credentials: serviceAccount,
       scopes: scopes,
     });
@@ -64,37 +58,20 @@ module.exports = ({ strapi }) => ({
     }
   },
   upload: async (ctx) => {
-    const fileInput = ctx.request.files?.files; // correct, showing the strapi terminal
-    // console.log('FILES', ctx.request.files);  
-    // console.log('BODY', ctx.request.body); // test whether the 'ctx.request.files?.files' is correct
-    
-
+    const fileInput = ctx.request.files?.files;
     if (!fileInput) {
       return ctx.badRequest('No files were uploaded');
     }
     const file = Array.isArray(fileInput) ? fileInput[0] : fileInput;
-    // console.log('file object:', file); // test
-
-    // if (!ctx.request.files) {
-    //   return ctx.badRequest('No files were uploaded');
-    // }
-
-    // const google_drive_service_account_path = get_service_account_path();
     const serviceAccount = strapi.config.get('plugin.googledrive.providerOptions.serviceAccount');
     const folderId = strapi.config.get('plugin.googledrive.providerOptions.folderId')
-
     const scopes = ['https://www.googleapis.com/auth/drive.file'];
 
     const auth = new google.auth.GoogleAuth({
-      // keyFile: google_drive_service_account_path,
       credentials: serviceAccount,
       scopes: scopes,
     });
     const drive = google.drive({ version: 'v3', auth });
-
-    // const {
-    //   request: { body, files: { files } = {} },
-    // } = ctx;
     
     const uploadSingleFile = async (fileName, fileType, filePath) => {
       const fsnp = require('fs');
@@ -142,33 +119,33 @@ module.exports = ({ strapi }) => ({
     }
   },
   deleteFile: async (ctx) => {
-    // const google_drive_service_account_path = get_service_account_path();
     const serviceAccount = strapi.config.get('plugin.googledrive.providerOptions.serviceAccount');
     const scopes = ['https://www.googleapis.com/auth/drive'];
 
     const auth = new google.auth.GoogleAuth({
-      // keyFile: google_drive_service_account_path,
       credentials: serviceAccount,
       scopes: scopes,
     });
 
     const drive = google.drive({ version: 'v3', auth });
-    // To send the file to trash
-    // const body_value = {
-    //   trashed: true,
-    // };
+    // Use permanent delete instead of moving the file to trash.
+    // Moving to trash requires 'Manager' permission for service account in Google Drive
     try {
-      const response = await drive.files.delete({ // use permanent delete
+      await drive.files.delete({
         fileId: ctx.request.params.fileId,
-        // requestBody: body_value,
         supportsAllDrives: true,
       });
-      // return response;
       return { success: true };
     } catch (error) {
-      if (error?.response?.status === 404) {
+      const status = error?.response?.status;
+
+      if (status === 404) {
         console.log('File already deleted');
         return { success: true };
+      }
+      if (status === 401) {
+        console.log('Unauthoried: service account cannot access the file');
+        return ctx.unauthorized('Service account does not have access to this file');
       }
       console.log(error);
       ctx.throw(500, 'Delete File Failed');

--- a/src/plugins/googledrive/server/services/operation-service.js
+++ b/src/plugins/googledrive/server/services/operation-service.js
@@ -154,20 +154,24 @@ module.exports = ({ strapi }) => ({
 
     const drive = google.drive({ version: 'v3', auth });
     // To send the file to trash
-    const body_value = {
-      trashed: true,
-    };
+    // const body_value = {
+    //   trashed: true,
+    // };
     try {
-      const response = await drive.files.update({
+      const response = await drive.files.delete({ // use permanent delete
         fileId: ctx.request.params.fileId,
-        requestBody: body_value,
+        // requestBody: body_value,
         supportsAllDrives: true,
       });
-      return response;
+      // return response;
+      return { success: true };
     } catch (error) {
+      if (error?.response?.status === 404) {
+        console.log('File already deleted');
+        return { success: true };
+      }
       console.log(error);
       ctx.throw(500, 'Delete File Failed');
-      return 'Delete File Failed';
     }
   },
 });

--- a/src/plugins/googledrive/server/services/operation-service.js
+++ b/src/plugins/googledrive/server/services/operation-service.js
@@ -137,7 +137,7 @@ module.exports = ({ strapi }) => ({
       });
       return { success: true };
     } catch (error) {
-      const status = error?.response?.status;
+      const status = error?.response?.status || error?.code;
 
       if (status === 404) {
         console.log('File already deleted');

--- a/src/plugins/googledrive/server/services/operation-service.js
+++ b/src/plugins/googledrive/server/services/operation-service.js
@@ -2,21 +2,25 @@
 const path = require('path');
 const process = require('process');
 const { google } = require('googleapis');
-const get_service_account_path = () => {
-  const service_account_path = path.join(
-    process.cwd(),
-    'config',
-    'env',
-    'google_drive_service_account.json'
-  );
-  return service_account_path;
-};
+// const get_service_account_path = () => {
+//   const service_account_path = path.join(
+//     process.cwd(),
+//     'config',
+//     'env',
+//     'google_drive_service_account.json'
+//   );
+//   return service_account_path;
+// };
 module.exports = ({ strapi }) => ({
   get: async (ctx) => {
-    const google_drive_service_account_path = get_service_account_path();
+    // const google_drive_service_account_path = get_service_account_path();
+    
+    const serviceAccount = strapi.config.get('plugin.googledrive.providerOptions.serviceAccount');
+
     const scopes = ['https://www.googleapis.com/auth/drive.metadata.readonly'];
     const auth = new google.auth.GoogleAuth({
-      keyFile: google_drive_service_account_path,
+      // keyFile: google_drive_service_account_path,
+      credentials: serviceAccount,
       scopes: scopes,
     });
     const drive = google.drive({ version: 'v3', auth });
@@ -60,29 +64,44 @@ module.exports = ({ strapi }) => ({
     }
   },
   upload: async (ctx) => {
-    if (!ctx.request.files) {
+    const fileInput = ctx.request.files?.files; // correct, showing the strapi terminal
+    // console.log('FILES', ctx.request.files);  
+    // console.log('BODY', ctx.request.body); // test whether the 'ctx.request.files?.files' is correct
+    
+
+    if (!fileInput) {
       return ctx.badRequest('No files were uploaded');
     }
+    const file = Array.isArray(fileInput) ? fileInput[0] : fileInput;
+    // console.log('file object:', file); // test
 
-    const google_drive_service_account_path = get_service_account_path();
+    // if (!ctx.request.files) {
+    //   return ctx.badRequest('No files were uploaded');
+    // }
+
+    // const google_drive_service_account_path = get_service_account_path();
+    const serviceAccount = strapi.config.get('plugin.googledrive.providerOptions.serviceAccount');
+    const folderId = strapi.config.get('plugin.googledrive.providerOptions.folderId')
 
     const scopes = ['https://www.googleapis.com/auth/drive.file'];
 
     const auth = new google.auth.GoogleAuth({
-      keyFile: google_drive_service_account_path,
+      // keyFile: google_drive_service_account_path,
+      credentials: serviceAccount,
       scopes: scopes,
     });
     const drive = google.drive({ version: 'v3', auth });
 
-    const {
-      request: { body, files: { files } = {} },
-    } = ctx;
+    // const {
+    //   request: { body, files: { files } = {} },
+    // } = ctx;
+    
     const uploadSingleFile = async (fileName, fileType, filePath) => {
       const fsnp = require('fs');
 
       const fileMetadata = {
         name: fileName,
-        parents: [process.env.FOLDERID],
+        parents: [folderId],
         mimeType: fileType, //mime-types to get the file types
       };
       const media = {
@@ -98,7 +117,7 @@ module.exports = ({ strapi }) => ({
           fields: 'id, name,parents,webViewLink,mimeType',
         });
 
-        if (!createResponse.data.parents.includes(process.env.FOLDERID)) {
+        if (!createResponse.data.parents.includes(folderId)) {
           throw new Error('File was not created in the expected folder.');
         }
         return createResponse.data;
@@ -111,9 +130,9 @@ module.exports = ({ strapi }) => ({
 
     try {
       const uploadResponse = await uploadSingleFile(
-        files['name'],
-        files['type'],
-        files.path
+        file.name,
+        file.type,
+        file.path
       );
       return uploadResponse;
     } catch (err) {
@@ -123,12 +142,13 @@ module.exports = ({ strapi }) => ({
     }
   },
   deleteFile: async (ctx) => {
-    const google_drive_service_account_path = get_service_account_path();
-
-    const scopes = ['https://www.googleapis.com/auth/drive.file'];
+    // const google_drive_service_account_path = get_service_account_path();
+    const serviceAccount = strapi.config.get('plugin.googledrive.providerOptions.serviceAccount');
+    const scopes = ['https://www.googleapis.com/auth/drive'];
 
     const auth = new google.auth.GoogleAuth({
-      keyFile: google_drive_service_account_path,
+      // keyFile: google_drive_service_account_path,
+      credentials: serviceAccount,
       scopes: scopes,
     });
 

--- a/workload/deployment.yaml
+++ b/workload/deployment.yaml
@@ -94,6 +94,11 @@ spec:
             configMapKeyRef:
               name: strapi-config
               key: url
+        - name: GOOGLE_DRIVE_FOLDERID
+          valueFrom:
+            secretKeyRef:
+              name: google-drive
+              key: folder-id
         - name: DEVLAUNCHERS_GOOGLE_DIRECTORY_JWT_SUBJECT
           valueFrom:
             secretKeyRef:


### PR DESCRIPTION
This PR adds the ability for users to upload files from their local device to Google Drive and delete them securely.

It ensures the service account has the necessary permissions, supports Shared Drives, and prevents 500 errors caused by insufficient access.

- Implemented a backend API for uploading files to Google Drive using service account credentials.
- Implemented a backend API for safely deleting files from Google Drive.
- Added error handling for insufficient permissions and other upload/delete failures.