### PR TITLE
add github secret to deployment

### DIFF
--- a/workload/deployment.yaml
+++ b/workload/deployment.yaml
@@ -165,6 +165,21 @@ spec:
             secretKeyRef:
               name: integrations
               key: sentry-dsn
+        - name: GITHUB_APP_ID
+          valueFrom:
+            secretKeyRef:
+              name: integrations
+              key: github-strapi-invite-new-member-app-id
+        - name: GITHUB_APP_INSTALLATION_ID
+          valueFrom:
+            secretKeyRef:
+              name: integrations
+              key: github-strapi-invite-new-member-app-installation-id
+        - name: GITHUB_APP_PRIVATE_KEY
+          valueFrom:
+            secretKeyRef:
+              name: integrations
+              key: github-strapi-invite-new-member-app-private-key
         - name: V_MATCH_USER
           valueFrom:
             secretKeyRef:


### PR DESCRIPTION
The GitHub App credentials (GITHUB_APP_ID, GITHUB_APP_INSTALLATION_ID, GITHUB_APP_PRIVATE_KEY) are defined in the integrations secret in k8s-infra, but were never mapped to environment variables in the deployment spec. As a result, these values were undefined at runtime, causing the GitHub org invite automation to fail silently.