### PR TITLE
Feat: #2748 (Backend) IdeaSpace Comment Notifications

### DIFF
--- a/src/api/comment/content-types/comment/lifecycles.js
+++ b/src/api/comment/content-types/comment/lifecycles.js
@@ -1,6 +1,5 @@
 module.exports = {
   beforeCreate(event) {
-    // Set author to the user sending the request
     const ctx = strapi.requestContext.get();
     event.params.data.user = ctx.state.user;
     event.params.data.author = ctx.state.user.username;
@@ -9,47 +8,102 @@ module.exports = {
   async afterCreate(event) {
     const { id: commentId, text: commentText } = event.result;
     const comment = await strapi.entityService.findOne(
-      "api::comment.comment",
-      commentId,
-      {
-        populate: ["idea_card", "user"],
-      }
+        "api::comment.comment",
+        commentId,
+        { populate: ["idea_card", "user"] }
     );
 
     const idea = comment.idea_card;
     const user = comment.user;
+    const currentUserId = user.id;
 
-    /** verify that user isn't already subscribed to ideaCard */
+    // Get idea owner
+    const ideaWithOwner = await strapi.entityService.findOne(
+        "api::idea-card.idea-card",
+        idea.id,
+        { populate: ["ideaOwner"] }
+    );
+    const ideaOwnerId = ideaWithOwner?.ideaOwner?.id;
+
+    // Get all EXISTING active subscribers for this idea,
+    // excluding the commenter AND the idea owner (added separately below)
     const existingSubscriptions = await strapi.entityService.findMany(
-      "api::subscription.subscription",
-      {
-        filters: { user: user, entityId: idea.id },
-        limit: 1,
-      }
+        "api::subscription.subscription",
+        {
+          filters: {
+            entityId: idea.id,
+            active: true,
+            $and: [
+              { user: { id: { $ne: currentUserId } } },
+              { user: { id: { $ne: ideaOwnerId } } },
+            ],
+          },
+          populate: ["user"],
+        }
     );
 
-    if (!existingSubscriptions.length)
+    // Build unique set of user IDs to notify
+    const usersToNotify = new Set();
+
+    // Add idea owner if they are not the commenter
+    if (ideaOwnerId && ideaOwnerId !== currentUserId) {
+      usersToNotify.add(ideaOwnerId);
+    }
+
+    // Add existing subscribers (already excludes commenter and owner)
+    for (const sub of existingSubscriptions) {
+      if (sub.user?.id) {
+        usersToNotify.add(sub.user.id);
+      }
+    }
+
+
+    // Subscribe the commenter if not already subscribed
+    const commenterSubscription = await strapi.entityService.findMany(
+        "api::subscription.subscription",
+        {
+          filters: { user: { id: currentUserId }, entityId: idea.id },
+          limit: 1,
+        }
+    );
+
+    if (!commenterSubscription.length) {
       await strapi.entityService.create("api::subscription.subscription", {
         data: {
-          entityType: "Comment",
+          entityType: "IdeaCard",  // Fixed: subscription is on the idea, not a comment
           entityId: idea.id,
           createdDateTime: new Date(),
           active: true,
-          user: user,
+          user: currentUserId,
         },
       });
+    }
 
-    await strapi.entityService.create("api::event.event", {
+    // Create the event record
+    const newEvent = await strapi.entityService.create("api::event.event", {
       data: {
         action: "Commented",
-        entityName: idea.ideaName,
+        entityName: ideaWithOwner.ideaName,
         content: commentText,
         entityType: "Comment",
         entityId: idea.id,
         originatedEntityId: commentId,
-        eventUser: user?.id,
+        eventUser: currentUserId,
         createdDateTime: new Date(),
       },
     });
+
+    // Create one notification per user to notify
+    for (const userId of usersToNotify) {
+      await strapi.entityService.create("api::notification.notification", {
+        data: {
+          user: userId,
+          event: newEvent.id,
+          createdDateTime: new Date(),
+          readDateTime: null,
+        },
+      });
+    }
+
   },
 };

--- a/src/api/event/content-types/event/lifecycles.js
+++ b/src/api/event/content-types/event/lifecycles.js
@@ -1,37 +1,45 @@
 module.exports = {
   async afterCreate(event) {
+
     // Extract the ID of the created event
-    const { id, entityId } = event.result;
+    const { id, entityId, action, entityType } = event.result;
+
+      // Comment notifications are fully handled in comment/lifecycles.js.
+    // Bail out here to prevent any possibility of duplicate notifications.
+    if (action === "Commented" || entityType === "Comment") {
+      console.log(`Skipping automatic notifications for comment event ${id}`);
+      return;
+    }
 
     try {
       // Fetch all users with active subscriptions for the given entityId
       const subscriptions = await strapi.entityService.findMany(
-        "api::subscription.subscription",
-        {
-          filters: {
-            entityId: entityId,
-            status: "active",
-          },
-          populate: ["user"],
-        }
+          "api::subscription.subscription",
+          {
+            filters: {
+              entityId: entityId,
+              active: true, // Changed from status: "active" to active: true
+            },
+            populate: ["user"],
+          }
       );
 
       // Generate notifications for each subscribed user
       await Promise.all(
-        subscriptions.map((subscription) => {
-          return strapi.entityService.create("api::notification.notification", {
-            data: {
-              createdDateTime: new Date().toISOString(),
-              readDateTime: null,
-              event: id,
-              user: subscription.user.id,
-            },
-          });
-        })
+          subscriptions.map((subscription) => {
+            return strapi.entityService.create("api::notification.notification", {
+              data: {
+                createdDateTime: new Date().toISOString(),
+                readDateTime: null,
+                event: id,
+                user: subscription.user.id,
+              },
+            });
+          })
       );
 
       console.log(
-        `Notifications created for event ${id} and ${subscriptions.length} subscribed users.`
+          `Notifications created for event ${id} and ${subscriptions.length} subscribed users.`
       );
     } catch (error) {
       console.error("Error creating notifications:", error);


### PR DESCRIPTION
## NOTE
[Mark Notifications as Read](https://github.com/dev-launchers/dev-launchers-platform/issues/2832) should be implemented alongside this feature. Otherwise these toasts will get noisy very quickly

### Background

This PR is 1 of 2 PR's. This implements backend changes for [#2748](https://github.com/dev-launchers/dev-launchers-platform/issues/2748). This should be merged **BEFORE** the [Frontend PR](https://github.com/dev-launchers/dev-launchers-platform/compare/2748-toastNotifications?expand=1).

### Summary

Implements the backend notification logic for comment activity on ideas. When a user comments on an idea, the relevant users are notified via the existing event/notification/subscription model.

### Changes

`comment/content-types/comment/lifecycles.js
`
* Added afterCreate lifecycle hook to handle notification creation when a comment is posted
* Fetches the idea owner and existing subscribers for the idea
* Builds a set of users to notify, explicitly excluding the commenter (no self-notifications)
* Creates a subscription for the commenter if one doesn't already exist
* Creates a single event record and one notification per user to notify

`event/content-types/event/lifecycles.js
`
* Added a guard to skip automatic notification creation for comment events (action === "Commented" or entityType === "Comment")
* This prevents duplicate notifications since comment notifications are handled entirely in comment/lifecycles.js

### Testing
* Tested locally using two accounts: one as idea owner, one as commenter. Verified in Strapi admin that exactly 1 notification is created for the correct user with no duplicates or self-notifications.