### PR TITLE
fix: 🐛 Implemented multi case scenario for partial index

### DIFF
--- a/src/migrators/ensure-partial-index.js
+++ b/src/migrators/ensure-partial-index.js
@@ -2,10 +2,12 @@
 
 async function ensureIdeaNameActiveIndex(strapi) {
   const knex = strapi.db.connection;
+  const hasSnakeCase = await knex.schema.hasColumn('idea_cards', 'idea_name');
+  const columnName = hasSnakeCase ? '"idea_name"' : '"ideaName"';
 
   await knex.raw(`
     CREATE UNIQUE INDEX IF NOT EXISTS idx_idea_cards_idea_name_active
-    ON idea_cards (LOWER("ideaName"))
+    ON idea_cards (LOWER(${columnName}))
     WHERE status <> 'deleted'
   `);
 }


### PR DESCRIPTION
Allowed both camel case and snake case column name for idea_name
strapi may convert column name from camel case to snake case.
This is to addressed missing column name for variable creation

✅ Closes: #2785