### PR TITLE
Add first and last name fields to profile

### DIFF
--- a/src/api/profile/content-types/profile/schema.json
+++ b/src/api/profile/content-types/profile/schema.json
@@ -45,6 +45,12 @@
       "allowedTypes": [
         "images"
       ]
+    },
+    "firstName": {
+      "type": "string"
+    },
+    "lastName": {
+      "type": "string"
     }
   }
 }

--- a/types/generated/contentTypes.d.ts
+++ b/types/generated/contentTypes.d.ts
@@ -1568,6 +1568,8 @@ export interface ApiProfileProfile extends Schema.CollectionType {
         maxLength: 20;
       }>;
     profilePicture: Attribute.Media;
+    firstName: Attribute.String;
+    lastName: Attribute.String;
     createdAt: Attribute.DateTime;
     updatedAt: Attribute.DateTime;
     publishedAt: Attribute.DateTime;


### PR DESCRIPTION
Related ticket: dev-launchers/dev-launchers-platform#2822

Added `firstName` and `lastName` fields to the Profile content type so the user profile details page can persist first and last name separately instead of deriving them from `displayName`.

This backend update supports the frontend work for the user profile details ticket.