### PR TITLE
chore: Allow running on AKS spot nodes

### DIFF
--- a/workload/deployment.yaml
+++ b/workload/deployment.yaml
@@ -23,6 +23,10 @@ spec:
       - key: virtual-kubelet.io/provider
         operator: Exists
         effect: PreferNoSchedule
+      - key: "kubernetes.azure.com/scalesetpriority"
+        operator: "Equal"
+        value: "spot"
+        effect: "NoSchedule"
       volumes:
         - name: google-directory-key
           secret:


### PR DESCRIPTION
Add toleration to allow scheduling pods on AKS spot nodes